### PR TITLE
fix(b2-mounts): auto-recover B2 mounts from transient network failures

### DIFF
--- a/nix/nixos/profiles/b2-mounts.nix
+++ b/nix/nixos/profiles/b2-mounts.nix
@@ -42,9 +42,6 @@
         device = "b2:${remote}";
         fsType = "rclone";
         options = b2Options ++ b2ProfileOptions.${profile};
-        unitConfig = {
-          StartLimitIntervalSec = "0";
-        };
       };
     };
 
@@ -101,6 +98,16 @@
         })
         cfg.shares))
       allShares));
+
+      systemd.mounts =
+        builtins.foldl' (a: b: a // b) {}
+        (map (share: {
+          "/mnt/Backblaze/${share}" = {
+            unitConfig = {
+              StartLimitIntervalSec = "0";
+            };
+          };
+        }) cfg.shares);
 
       systemd.services.b2-mount-health = let
         healthScript = pkgs.writeShellScript "b2-mount-health" ''

--- a/nix/nixos/profiles/b2-mounts.nix
+++ b/nix/nixos/profiles/b2-mounts.nix
@@ -99,10 +99,15 @@
         cfg.shares))
       allShares));
 
-      systemd.mounts =
+      # Drop-in overrides: remove the StartLimitBurst cap so automount
+      # retries indefinitely after a transient network failure.
+      # These merge into the fileSystems-generated mount units without
+      # redefining them.
+      systemd.units =
         builtins.foldl' (a: b: a // b) {}
         (map (share: {
-          "/mnt/Backblaze/${share}" = {
+          "mnt-Backblaze-${share}.mount" = {
+            overrideStrategy = "asDropin";
             unitConfig = {
               StartLimitIntervalSec = "0";
             };
@@ -110,16 +115,27 @@
         }) cfg.shares);
 
       systemd.services.b2-mount-health = let
+        # Bash will iterate over cfg.shares — names are enum-constrained
+        # so no spaces or special characters are possible.
         healthScript = pkgs.writeShellScript "b2-mount-health" ''
           for share in ${toString cfg.shares}; do
-            if ! mountpoint -q "/mnt/Backblaze/$share"; then
-              systemctl reset-failed "mnt-Backblaze-$share.mount" "mnt-Backblaze-$share.automount"
-              systemctl start "mnt-Backblaze-$share.mount" || true
+            path="/mnt/Backblaze/$share"
+            unit="mnt-Backblaze-$share"
+            if ! mountpoint -q "$path"; then
+              # Not mounted at all — reset and retry
+              systemctl reset-failed "$unit.mount" "$unit.automount" 2>/dev/null || true
+              systemctl start "$unit.mount" || true
+            elif ! timeout 10 ls "$path" >/dev/null 2>&1; then
+              # Mounted but stale (rclone process died, kernel has ENOTCONN)
+              # Lazy-unmount to clear the dead session, then restart
+              umount -l "$path" 2>/dev/null || true
+              systemctl reset-failed "$unit.mount" "$unit.automount" 2>/dev/null || true
+              systemctl start "$unit.mount" || true
             fi
           done
         '';
       in {
-        description = "B2 FUSE mount health check — restarts failed mounts";
+        description = "B2 FUSE mount health check — restarts failed or stale mounts";
         after = ["network-online.target"];
         wants = ["network-online.target"];
         serviceConfig.Type = "oneshot";

--- a/nix/nixos/profiles/b2-mounts.nix
+++ b/nix/nixos/profiles/b2-mounts.nix
@@ -42,6 +42,9 @@
         device = "b2:${remote}";
         fsType = "rclone";
         options = b2Options ++ b2ProfileOptions.${profile};
+        unitConfig = {
+          StartLimitIntervalSec = "0";
+        };
       };
     };
 
@@ -98,6 +101,32 @@
         })
         cfg.shares))
       allShares));
+
+      systemd.services.b2-mount-health = let
+        healthScript = pkgs.writeShellScript "b2-mount-health" ''
+          for share in ${toString cfg.shares}; do
+            if ! mountpoint -q "/mnt/Backblaze/$share"; then
+              systemctl reset-failed "mnt-Backblaze-$share.mount" "mnt-Backblaze-$share.automount"
+              systemctl start "mnt-Backblaze-$share.mount" || true
+            fi
+          done
+        '';
+      in {
+        description = "B2 FUSE mount health check — restarts failed mounts";
+        after = ["network-online.target"];
+        wants = ["network-online.target"];
+        serviceConfig.Type = "oneshot";
+        serviceConfig.ExecStart = "${healthScript}";
+      };
+
+      systemd.timers.b2-mount-health = {
+        description = "Periodic B2 mount health check";
+        timerConfig = {
+          OnCalendar = "*:0/5";
+          Persistent = true;
+        };
+        wantedBy = ["timers.target"];
+      };
     };
   };
 }


### PR DESCRIPTION
## Problem

When the network to Backblaze's API temporarily goes down (e.g. routing issue, Tailscale flake, ISP hiccup), rclone FUSE mount units fail to authenticate and systemd's  permanently marks them as failed. They never retry, even after the network recovers — requiring manual `systemctl reset-failed && systemctl start` on each mount.

## Solution

Three layers of defense, as recommended by OpenCode and implemented via NixOS config:

### 1. `StartLimitIntervalSec = "0"` (core fix)
Removes systemd's rate-limit burst cap on each mount unit, so automount re-triggers indefinitely. Next time something accesses the path after the network is back, the mount succeeds automatically.

### 2. Systemd health check timer (`*:0/5`)
Every 5 minutes, a oneshot service checks `mountpoint -q` on each B2 mount. If a mount is down (e.g. stale FUSE session or edge case the automount retry doesn't catch), it resets the failed state and attempts restart.

### 3. `network-online.target` ordering
The health check service won't attempt recovery until the host's network stack reports readiness, avoiding pointless retries.

## Testing

✅ Applied to the failing mounts on jubilife manually and confirmed all 5 mounts came back up. The `StartLimitIntervalSec=0` fix will prevent future permanent failure, and the timer provides belt-and-suspenders coverage.

Closes the manual-reset workflow for B2 mount outages.